### PR TITLE
Use node label instead of node-role

### DIFF
--- a/helm/loki-stack-app/charts/fluent-bit/values.yaml
+++ b/helm/loki-stack-app/charts/fluent-bit/values.yaml
@@ -71,7 +71,7 @@ serviceAccount:
 ## Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations:
-- key: node-role.kubernetes.io/master
+- key: node.kubernetes.io/master
   effect: NoSchedule
 
 # Extra volumes to scrape logs from

--- a/helm/loki-stack-app/charts/promtail/values.yaml
+++ b/helm/loki-stack-app/charts/promtail/values.yaml
@@ -79,7 +79,7 @@ serviceAccount:
 ## Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations:
-- key: node-role.kubernetes.io/master
+- key: node.kubernetes.io/master
   operator: Exists
   effect: NoSchedule
 


### PR DESCRIPTION
With kubernetes 1.16 the node-role label is deprecated and we switch to the node label instead

towards giantswarm/giantswarm#7428 and giantswarm/giantswarm#7824