### PR TITLE
Update icon URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.4.3
+  architect: giantswarm/architect@0.14.0
 
 workflows:
   package-and-push-chart-on-tag:

--- a/helm/loki-stack-app/Chart.yaml
+++ b/helm/loki-stack-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v1.2.0
 description: 'Loki: like Prometheus, but for logs.'
 engine: gotpl
 home: https://grafana.com/loki
-icon: https://github.com/grafana/loki/raw/master/docs/logo.png
+icon: https://raw.githubusercontent.com/grafana/loki/5a8bc848dbe453ce27576d2058755a90f79d07b6/docs/sources/logo.png
 kubeVersion: ^1.10.0-0
 maintainers:
 - email: lokiproject@googlegroups.com

--- a/helm/loki-stack-app/requirements.lock
+++ b/helm/loki-stack-app/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: loki
-  repository: file://../loki
+  repository: ""
   version: 0.21.0
 - name: promtail
-  repository: file://../promtail
+  repository: ""
   version: 0.16.0
-digest: sha256:92073f41b99041a215335b957fd32e32d313410f3c28232fa9650711c86fc77a
-generated: "2019-12-13T13:40:33.214634668+01:00"
+digest: sha256:c237102f314a2d9407388970fbcc25879e5a09a028225462f201159601ec5d13
+generated: "2020-10-16T15:17:39.69845371+02:00"

--- a/helm/loki-stack-app/requirements.yaml
+++ b/helm/loki-stack-app/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: "loki"
   condition: loki.enabled
-  repository: "file://../charts/loki"
+  repository: "file://./charts/loki"
   version: "^0.6.0"
 - name: "promtail"
   condition: promtail.enabled
-  repository: "file://../charts/promtail"
+  repository: "file://./charts/promtail"
   version: "^0.6.0"

--- a/helm/loki-stack-app/requirements.yaml
+++ b/helm/loki-stack-app/requirements.yaml
@@ -1,9 +1,7 @@
 dependencies:
 - name: "loki"
   condition: loki.enabled
-  repository: "file://./charts/loki"
-  version: "^0.6.0"
+  version: "0.21.0"
 - name: "promtail"
   condition: promtail.enabled
-  repository: "file://./charts/promtail"
-  version: "^0.6.0"
+  version: "0.16.0"

--- a/helm/loki-stack-app/requirements.yaml
+++ b/helm/loki-stack-app/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: "loki"
   condition: loki.enabled
-  repository: "file://../loki"
+  repository: "file://../charts/loki"
   version: "^0.6.0"
 - name: "promtail"
   condition: promtail.enabled
-  repository: "file://../promtail"
+  repository: "file://../charts/promtail"
   version: "^0.6.0"


### PR DESCRIPTION
The old icon URL was a 404, hence the app is currently displayed without logo.

![image](https://user-images.githubusercontent.com/273727/96252135-c5f92680-0fb1-11eb-853d-2be31f86ec32.png)

In order to enable CI again, this also updates architect-orb to the latest version.